### PR TITLE
Pass filepath to rigger

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,19 @@ module.exports = function (options) {
     options = options || {};
 
     return es.map(function (file, cb) {
-	if(!options.cwd){
-	        options.cwd = path.dirname(file.path);
-	}
-	if(!options.filetype){
-	        options.filetype = path.extname(file.path).slice(1);
-	}
-	if(!options.targetType){
-	        options.targetType = path.extname(file.path).slice(1);
-	}
+        if(!options.cwd){
+                options.cwd = path.dirname(file.path);
+        }
+        if(!options.filetype){
+                options.filetype = path.extname(file.path).slice(1);
+        }
+        // CHANGED: send full file path to rigger to avoid self-inclusion
+        if(!options.filepath){
+            options.filepath = file.path;
+        }
+        if(!options.targetType){
+                options.targetType = path.extname(file.path).slice(1);
+        }
 
         rigger.process(file.contents.toString(), options, function (error, content) {
             file.contents = new Buffer(content);


### PR DESCRIPTION
Previously, when doing a directory import, rigger did not consider that the importing file would be in the directory being imported, and it would wind up doing one recursion of self-inclusion.  This change is
part of a small fix that keeps rigger from importing a file into itself - in the `_getSingle` method, the imported files are checked against the original file path, and if they match exactly, then the imported
file is marked as not valid for import.

I've also submitted another pull request to the original Rigger repo to add the fix I mentioned, but the changes in this pull request should be benign even if it takes the rigger author a while to accept the pull request.
